### PR TITLE
Feature/multiplayer fog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ TBD
 - Fog of war.
   - Hides enemies when covered in fog.
   - Hides obstacles when covered in fog unless the obstacle has been uncovered before.
-  - Reveals contents when the player figurine is in range and hides it again when the player figurine is out of range again.
+  - Reveals contents when any of the player's figurines is in range and hides it again when the player's figurines are out of range again.

--- a/SNEL-VR/Assets/Objects/EnvironmentalEffects/FogOfWar/FogElement.prefab
+++ b/SNEL-VR/Assets/Objects/EnvironmentalEffects/FogOfWar/FogElement.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 865640660686519456}
   m_Layer: 0
   m_Name: FogElement
-  m_TagString: Fog
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -46,7 +46,7 @@ GameObject:
   - component: {fileID: 865640661906320684}
   m_Layer: 0
   m_Name: FogCell
-  m_TagString: Untagged
+  m_TagString: Fog
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -135,5 +135,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ec0cdbb16a555944be36a3488836fab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hasBeenRevealedMaterial: {fileID: 2100000, guid: 3aad85ee5af83994bb3980943b48dc0c,
-    type: 2}

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
@@ -13,9 +13,10 @@ GameObject:
   - component: {fileID: 3508976374353388247}
   - component: {fileID: 7605154039241910277}
   - component: {fileID: 2895457433700266041}
+  - component: {fileID: 783977817673062877}
   m_Layer: 0
   m_Name: Figurine
-  m_TagString: Untagged
+  m_TagString: NPCFigurine
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -28,7 +29,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2691590353112806813}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 0.39999998, y: 0.5, z: 0.39999998}
   m_Children: []
   m_Father: {fileID: 592458350434367236}
@@ -109,6 +110,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &783977817673062877
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2691590353112806813}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c9a2831845ee1c409eec91cd3f10562, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3054508066924389319
 GameObject:
   m_ObjectHideFlags: 0
@@ -119,8 +132,8 @@ GameObject:
   m_Component:
   - component: {fileID: 592458350434367236}
   m_Layer: 0
-  m_Name: Enemy figurine
-  m_TagString: NPCFigurine
+  m_Name: Figurine_Enemy
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -133,7 +146,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3054508066924389319}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1185474669484261747}

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
@@ -13,9 +13,10 @@ GameObject:
   - component: {fileID: 8829548002214755655}
   - component: {fileID: 8829548002214755704}
   - component: {fileID: 8829548002214755705}
+  - component: {fileID: 6057943356348471409}
   m_Layer: 0
   m_Name: Figurine
-  m_TagString: Untagged
+  m_TagString: PlayerFigurine
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -109,6 +110,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &6057943356348471409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8829548002214755707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c9a2831845ee1c409eec91cd3f10562, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8829548002790330799
 GameObject:
   m_ObjectHideFlags: 0
@@ -120,7 +133,7 @@ GameObject:
   - component: {fileID: 8829548002790330798}
   m_Layer: 0
   m_Name: Figurine_Player
-  m_TagString: PlayerFigurine
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
+++ b/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2950841269136768741}
   - component: {fileID: 2950841269136768740}
   - component: {fileID: 2950841269136768743}
+  - component: {fileID: 1578742081763624466}
   m_Layer: 9
   m_Name: WallSegment
   m_TagString: Obstacle
@@ -108,6 +109,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 126
   m_CollisionDetection: 0
+--- !u!114 &1578742081763624466
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2950841269136768737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56bfa57c058a6a04cbc5858cd152f40f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2950841269433147972
 GameObject:
   m_ObjectHideFlags: 0

--- a/SNEL-VR/Assets/Objects/Player.prefab
+++ b/SNEL-VR/Assets/Objects/Player.prefab
@@ -95,6 +95,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fef1b1f1dac4624b8225e8bd765721b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  unvisitedFogMaterial: {fileID: 2100000, guid: 2af6b76083ea025448b1fdba5a40dcbb,
+    type: 2}
+  visitedFogMaterial: {fileID: 2100000, guid: 3aad85ee5af83994bb3980943b48dc0c, type: 2}
 --- !u!1 &5927008980755459714
 GameObject:
   m_ObjectHideFlags: 0

--- a/SNEL-VR/Assets/Objects/Player.prefab
+++ b/SNEL-VR/Assets/Objects/Player.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5927008980431827238}
   - component: {fileID: 5927008980431827239}
   - component: {fileID: 5927008980431827256}
+  - component: {fileID: 8861512689432105826}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -62,7 +63,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 823
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -82,6 +83,18 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5927008980431827257}
   m_Enabled: 1
+--- !u!114 &8861512689432105826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5927008980431827257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9fef1b1f1dac4624b8225e8bd765721b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5927008980755459714
 GameObject:
   m_ObjectHideFlags: 0
@@ -94,6 +107,7 @@ GameObject:
   - component: {fileID: 5927008980755459712}
   - component: {fileID: 5927008980755459726}
   - component: {fileID: 5927008980755459713}
+  - component: {fileID: 3586409532311624467}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -162,3 +176,16 @@ MonoBehaviour:
   lookSensitivity: 100
   inputMethod: 1
   rb: {fileID: 5927008980755459712}
+--- !u!114 &3586409532311624467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5927008980755459714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 420b744de58945f48910a62192b87734, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ownedFigurine: {fileID: 0}

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -368,6 +368,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 787621112}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1036882150 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8829548002790330799, guid: 0919273d5666bf944ba903096ea2cc5a,
+    type: 3}
+  m_PrefabInstance: {fileID: 217249143}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1036882151 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
@@ -751,9 +757,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3586409532311624467, guid: 6285edf1928d51d409384c43890914ec,
         type: 3}
+      propertyPath: inputFigurines.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3586409532311624467, guid: 6285edf1928d51d409384c43890914ec,
+        type: 3}
       propertyPath: ownedFigurine
       value: 
       objectReference: {fileID: 1008646610}
+    - target: {fileID: 3586409532311624467, guid: 6285edf1928d51d409384c43890914ec,
+        type: 3}
+      propertyPath: inputFigurines.Array.data[0]
+      value: 
+      objectReference: {fileID: 1008646610}
+    - target: {fileID: 3586409532311624467, guid: 6285edf1928d51d409384c43890914ec,
+        type: 3}
+      propertyPath: inputFigurines.Array.data[1]
+      value: 
+      objectReference: {fileID: 1036882150}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6285edf1928d51d409384c43890914ec, type: 3}
 --- !u!1001 &7647315897910301335

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -112,6 +112,75 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &217249143
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1057895930}
+    m_Modifications:
+    - target: {fileID: 8829548002790330799, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_Name
+      value: Figurine_Player2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0919273d5666bf944ba903096ea2cc5a, type: 3}
 --- !u!1001 &246458480
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -228,7 +297,7 @@ PrefabInstance:
     - target: {fileID: 8829548002790330799, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
       propertyPath: m_Name
-      value: Figurine_Player
+      value: Figurine_Player1
       objectReference: {fileID: 0}
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
@@ -299,6 +368,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 787621112}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1036882151 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+    type: 3}
+  m_PrefabInstance: {fileID: 217249143}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1057895929
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,6 +403,7 @@ Transform:
   m_Children:
   - {fileID: 787621113}
   - {fileID: 1502211475}
+  - {fileID: 1036882151}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -112,12 +112,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!4 &182316536 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-    type: 3}
-  m_PrefabInstance: {fileID: 493832383}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &246458480
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -187,80 +181,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0066209f147558e4aaa50845efe55dcf, type: 3}
---- !u!1001 &493832383
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1057895930}
-    m_Modifications:
-    - target: {fileID: 3054508066924389319, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_Name
-      value: Figurine_Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 3054508066924389319, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 66f8d895dabee83468dba0de87b8946b, type: 3}
 --- !u!1 &644313889
 GameObject:
   m_ObjectHideFlags: 0
@@ -287,7 +207,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1500682847}
   m_Father: {fileID: 2006786384}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -312,7 +233,7 @@ PrefabInstance:
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -8
       objectReference: {fileID: 0}
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
@@ -347,7 +268,7 @@ PrefabInstance:
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
@@ -369,6 +290,12 @@ PrefabInstance:
 --- !u!4 &787621113 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
+    type: 3}
+  m_PrefabInstance: {fileID: 787621112}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1008646610 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8829548002790330799, guid: 0919273d5666bf944ba903096ea2cc5a,
     type: 3}
   m_PrefabInstance: {fileID: 787621112}
   m_PrefabAsset: {fileID: 0}
@@ -399,8 +326,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 182316536}
   - {fileID: 787621113}
+  - {fileID: 1502211475}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -410,6 +337,156 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 15275098845626759}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1500682846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 644313890}
+    m_Modifications:
+    - target: {fileID: 4637816363565740481, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_Name
+      value: Obstacle_Wall
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 194a84b963922914b8e943b4d07649a7, type: 3}
+--- !u!4 &1500682847 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1500682846}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1502211475 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1650298308}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1650298308
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1057895930}
+    m_Modifications:
+    - target: {fileID: 3054508066924389319, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_Name
+      value: Figurine_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 66f8d895dabee83468dba0de87b8946b, type: 3}
 --- !u!4 &1894359469 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
@@ -596,6 +673,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3586409532311624467, guid: 6285edf1928d51d409384c43890914ec,
+        type: 3}
+      propertyPath: ownedFigurine
+      value: 
+      objectReference: {fileID: 1008646610}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6285edf1928d51d409384c43890914ec, type: 3}
 --- !u!1001 &7647315897910301335

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
@@ -26,8 +26,6 @@ public class Figurine_ObservedBy : MonoBehaviour
 
     public GameObject[] GetObservedBy()
     {
-        GameObject[] retList = new GameObject[observedBy.Count];
-        observedBy.CopyTo(retList);
-        return retList;
+        return observedBy.ToArray();
     }
 }

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Figurine_ObservedBy : MonoBehaviour
+{
+    private List<GameObject> observedBy = new List<GameObject>();
+
+    public void AddObserver(GameObject observer)
+    {
+        if (!observedBy.Contains(observer))
+        {
+            observedBy.Add(observer);
+        }
+    }
+
+    public void RemoveObserver(GameObject observer)
+    {
+        observedBy.Remove(observer);
+    }
+
+    public void ClearObservers()
+    {
+        observedBy.Clear();
+    }
+
+    public GameObject[] GetObservedBy()
+    {
+        GameObject[] retList = new GameObject[observedBy.Count];
+        observedBy.CopyTo(retList);
+        return retList;
+    }
+}

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs.meta
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c9a2831845ee1c409eec91cd3f10562
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
@@ -6,7 +6,7 @@ public class Figurine_PlayerVision : MonoBehaviour
 {
     private static float sensitivity = 0.00000001f;
 
-    private bool hasMoved = false;
+    private bool hasMoved = true;
     private bool shouldUpdate = false;
 
     private Vector3 oldPos;

--- a/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
+++ b/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
@@ -146,15 +146,11 @@ public class FogHideOtherObject : MonoBehaviour
 
     public GameObject[] GetObservedBy()
     {
-        GameObject[] retList = new GameObject[observedBy.Count];
-        observedBy.CopyTo(retList);
-        return retList;
+        return observedBy.ToArray();
     }
 
     public GameObject[] getHasBeenObservedBy()
     {
-        GameObject[] retList = new GameObject[hasBeenObservedBy.Count];
-        hasBeenObservedBy.CopyTo(retList);
-        return retList;
+        return hasBeenObservedBy.ToArray();
     }
 }

--- a/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
+++ b/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class FogHideOtherObject : MonoBehaviour
 {
-    private List<Collider> npcColliders = new List<Collider>();
+    private List<Collider> figurineColliders = new List<Collider>();
     private List<Collider> obstacleColliders = new List<Collider>();
 
     private List<GameObject> observedBy = new List<GameObject>();
@@ -12,8 +12,8 @@ public class FogHideOtherObject : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        // What to do when colliding with an NPC figurine.
-        if (ColliderHasTag(other, "NPCFigurine"))
+        // What to do when colliding with a figurine.
+        if (ColliderHasTag(other, "NPCFigurine") || ColliderHasTag(other, "PlayerFigurine"))
         {
             // Reset the figurines observers.
             other.gameObject.GetComponent<Figurine_ObservedBy>().ClearObservers();
@@ -24,9 +24,9 @@ public class FogHideOtherObject : MonoBehaviour
                 MakeVisible(other, observedBy[i]);
             }
 
-            if (!npcColliders.Contains(other))
+            if (!figurineColliders.Contains(other))
             {
-                npcColliders.Add(other);
+                figurineColliders.Add(other);
             }
         }
         // What to do when colliding with an obstacle.
@@ -47,9 +47,9 @@ public class FogHideOtherObject : MonoBehaviour
 
     private void OnTriggerExit(Collider other)
     {
-        if (ColliderHasTag(other, "NPCFigurine"))
+        if (ColliderHasTag(other, "NPCFigurine") || ColliderHasTag(other, "PlayerFigurine"))
         {
-            npcColliders.Remove(other);
+            figurineColliders.Remove(other);
         }
         else if (ColliderHasTag(other, "Obstacle"))
         {
@@ -88,9 +88,9 @@ public class FogHideOtherObject : MonoBehaviour
     private void RevealContents(GameObject figurine)
     {
         // Make all NPC figurines visible
-        for (int i = 0; i < npcColliders.Count; i++)
+        for (int i = 0; i < figurineColliders.Count; i++)
         {
-            MakeVisible(npcColliders[i], figurine);
+            MakeVisible(figurineColliders[i], figurine);
         }
 
         // Make all obstacles visible
@@ -104,9 +104,9 @@ public class FogHideOtherObject : MonoBehaviour
     private void HideContents(GameObject figurine)
     {
         // Make all NPC figurines visible
-        for (int i = 0; i < npcColliders.Count; i++)
+        for (int i = 0; i < figurineColliders.Count; i++)
         {
-            MakeInvisible(npcColliders[i], figurine);
+            MakeInvisible(figurineColliders[i], figurine);
         }
     }
 
@@ -122,7 +122,7 @@ public class FogHideOtherObject : MonoBehaviour
     }
     private void MakeInvisible(GameObject go, GameObject figurine)
     {
-        if (go.CompareTag("NPCFigurine"))
+        if (go.CompareTag("NPCFigurine") || go.CompareTag("PlayerFigurine"))
         {
             go.GetComponent<Figurine_ObservedBy>().RemoveObserver(figurine);
         }
@@ -134,7 +134,7 @@ public class FogHideOtherObject : MonoBehaviour
     }
     private void MakeVisible(GameObject go, GameObject figurine)
     {
-        if (go.CompareTag("NPCFigurine"))
+        if (go.CompareTag("NPCFigurine") || go.CompareTag("PlayerFigurine"))
         {
             go.GetComponent<Figurine_ObservedBy>().AddObserver(figurine);
         }

--- a/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
+++ b/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
@@ -23,6 +23,11 @@ public class FogHideOtherObject : MonoBehaviour
             {
                 MakeVisible(other, observedBy[i]);
             }
+
+            if (!npcColliders.Contains(other))
+            {
+                npcColliders.Add(other);
+            }
         }
         // What to do when colliding with an obstacle.
         else if (ColliderHasTag(other, "Obstacle"))
@@ -32,6 +37,23 @@ public class FogHideOtherObject : MonoBehaviour
             {
                 MakeVisible(other, observedBy[i]);
             }
+
+            if (!obstacleColliders.Contains(other))
+            {
+                obstacleColliders.Add(other);
+            }
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (ColliderHasTag(other, "NPCFigurine"))
+        {
+            npcColliders.Remove(other);
+        }
+        else if (ColliderHasTag(other, "Obstacle"))
+        {
+            obstacleColliders.Remove(other);
         }
     }
 

--- a/SNEL-VR/Assets/Scripts/ObstacleScripts.meta
+++ b/SNEL-VR/Assets/Scripts/ObstacleScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 385354dee66cca047a2af55651e2c721
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
+++ b/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Obstacle_RevealedTo : MonoBehaviour
+{
+    private List<GameObject> observedBy = new List<GameObject>();
+
+    public void AddObserver(GameObject observer)
+    {
+        if (!observedBy.Contains(observer))
+        {
+            observedBy.Add(observer);
+        }
+    }
+
+    public GameObject[] GetObservedBy()
+    {
+        GameObject[] retList = new GameObject[observedBy.Count];
+        observedBy.CopyTo(retList);
+        return retList;
+    }
+}

--- a/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
+++ b/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
@@ -16,8 +16,6 @@ public class Obstacle_RevealedTo : MonoBehaviour
 
     public GameObject[] GetObservedBy()
     {
-        GameObject[] retList = new GameObject[observedBy.Count];
-        observedBy.CopyTo(retList);
-        return retList;
+        return observedBy.ToArray();
     }
 }

--- a/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs.meta
+++ b/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56bfa57c058a6a04cbc5858cd152f40f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
@@ -10,53 +10,83 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
     private Camera cam;
     private PlayerOwnedFigurines figs;
 
+    private static int defaultLayer = 0;
+    private static int invisibleLayer = 10;
+    private static int obstacleLayer = 9;
+
+    // Startby fetching the script tracking the figurines owned by the player.
     private void Start()
     {
         figs = GetComponent<Transform>().parent.gameObject.GetComponent<PlayerOwnedFigurines>();
     }
 
+    // Makes any object that should not be visible by this camera invisible by changing their layer
+    // right before the culling.
     private void CullInvisible(Camera cam)
     {
+        // Put all NPC figurines visible by any owned figurines in the default layer and the rest
+        // in the invisible layer.
         foreach (GameObject npc in GameObject.FindGameObjectsWithTag("NPCFigurine"))
         {
             if (OwnedIsIn(npc.GetComponent<Figurine_ObservedBy>().GetObservedBy()))
             {
-                npc.layer = 0;
+                npc.layer = defaultLayer;
             }
             else
             {
-                npc.layer = 10;
+                npc.layer = invisibleLayer;
             }
         }
 
+        // Put all obstacles that are not visible to any owned figurines in the invisible layer.
         foreach (GameObject obs in GameObject.FindGameObjectsWithTag("Obstacle"))
         {
             if (!OwnedIsIn(obs.GetComponent<Obstacle_RevealedTo>().GetObservedBy()))
             {
-                obs.layer = 10;
+                obs.layer = invisibleLayer;
             }
         }
 
+        // Put all fog elements visible by any owned figurines in the default layer and the rest
+        // in the invisible layer.
         foreach (GameObject fog in GameObject.FindGameObjectsWithTag("Fog"))
         {
             if (OwnedIsIn(fog.GetComponent<FogHideOtherObject>().GetObservedBy()))
             {
-                fog.layer = 10;
+                fog.layer = invisibleLayer;
             }
             else
             {
-                fog.layer = 0;
+                fog.layer = defaultLayer;
+            }
+        }
+
+        // Puts all player figurines owned by the player or visible to figurines owned by the
+        // player in the default layer and the rest in the invisible layer.
+        foreach (GameObject fig in GameObject.FindGameObjectsWithTag("PlayerFigurine"))
+        {
+            if (IsOwned(fig) || OwnedIsIn(fig.GetComponent<Figurine_ObservedBy>().GetObservedBy()))
+            {
+                fig.layer = defaultLayer;
+            }
+            else
+            {
+                fig.layer = invisibleLayer;
             }
         }
     }
 
+    // Updates textures and resets obstacles' layer before rendering.
     private void OnPreRender()
     {
+        // Put all obstacles in the obstacle layer.
         foreach (GameObject obs in GameObject.FindGameObjectsWithTag("Obstacle"))
         {
-            obs.layer = 9;
+            obs.layer = obstacleLayer;
         }
 
+        // Update the material of all fog elements based on whether the owned figurines have
+        // at some points seen them or not.
         foreach (GameObject fog in GameObject.FindGameObjectsWithTag("Fog"))
         {
             if (OwnedIsIn(fog.GetComponent<FogHideOtherObject>().getHasBeenObservedBy()))
@@ -70,11 +100,25 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
         }
     }
 
+    // Checks if any object in the input array is owned by the player.
     private bool OwnedIsIn(GameObject[] visTo)
     {
         foreach (GameObject v in visTo)
         {
-            if (figs.ownedFigurine.Equals(v))
+            if (IsOwned(v))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Checks if the input object is owned by the player.
+    private bool IsOwned(GameObject obj)
+    {
+        foreach (GameObject own in figs.GetOwnedFigurines())
+        {
+            if (own.Equals(obj))
             {
                 return true;
             }

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class PlayerDisplayObjectDecider : MonoBehaviour
 {
+    public Material unvisitedFogMaterial;
+    public Material visitedFogMaterial;
+
     private Camera cam;
     private PlayerOwnedFigurines figs;
 
@@ -14,13 +17,9 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
 
     private void CullInvisible(Camera cam)
     {
-        GameObject[] npcFigurines = GameObject.FindGameObjectsWithTag("NPCFigurine");
-        GameObject[] obstacles = GameObject.FindGameObjectsWithTag("Obstacle");
-        GameObject[] fogCells = GameObject.FindGameObjectsWithTag("Fog");
-
-        foreach (GameObject npc in npcFigurines)
+        foreach (GameObject npc in GameObject.FindGameObjectsWithTag("NPCFigurine"))
         {
-            if (IsViewedBy(npc.GetComponent<Figurine_ObservedBy>().GetObservedBy()))
+            if (OwnedIsIn(npc.GetComponent<Figurine_ObservedBy>().GetObservedBy()))
             {
                 npc.layer = 0;
             }
@@ -30,17 +29,17 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
             }
         }
 
-        foreach (GameObject obs in obstacles)
+        foreach (GameObject obs in GameObject.FindGameObjectsWithTag("Obstacle"))
         {
-            if (!IsViewedBy(obs.GetComponent<Obstacle_RevealedTo>().GetObservedBy()))
+            if (!OwnedIsIn(obs.GetComponent<Obstacle_RevealedTo>().GetObservedBy()))
             {
                 obs.layer = 10;
             }
         }
 
-        foreach (GameObject fog in fogCells)
+        foreach (GameObject fog in GameObject.FindGameObjectsWithTag("Fog"))
         {
-            if (IsViewedBy(fog.GetComponent<FogHideOtherObject>().GetObservedBy()))
+            if (OwnedIsIn(fog.GetComponent<FogHideOtherObject>().GetObservedBy()))
             {
                 fog.layer = 10;
             }
@@ -57,9 +56,21 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
         {
             obs.layer = 9;
         }
+
+        foreach (GameObject fog in GameObject.FindGameObjectsWithTag("Fog"))
+        {
+            if (OwnedIsIn(fog.GetComponent<FogHideOtherObject>().getHasBeenObservedBy()))
+            {
+                fog.GetComponent<Renderer>().material = visitedFogMaterial;
+            }
+            else
+            {
+                fog.GetComponent<Renderer>().material = unvisitedFogMaterial;
+            }
+        }
     }
 
-    private bool IsViewedBy(GameObject[] visTo)
+    private bool OwnedIsIn(GameObject[] visTo)
     {
         foreach (GameObject v in visTo)
         {

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerDisplayObjectDecider : MonoBehaviour
+{
+    private Camera cam;
+    private PlayerOwnedFigurines figs;
+
+    private void Start()
+    {
+        figs = GetComponent<Transform>().parent.gameObject.GetComponent<PlayerOwnedFigurines>();
+    }
+
+    private void CullInvisible(Camera cam)
+    {
+        GameObject[] npcFigurines = GameObject.FindGameObjectsWithTag("NPCFigurine");
+        GameObject[] obstacles = GameObject.FindGameObjectsWithTag("Obstacle");
+        GameObject[] fogCells = GameObject.FindGameObjectsWithTag("Fog");
+
+        foreach (GameObject npc in npcFigurines)
+        {
+            if (IsViewedBy(npc.GetComponent<Figurine_ObservedBy>().GetObservedBy()))
+            {
+                npc.layer = 0;
+            }
+            else
+            {
+                npc.layer = 10;
+            }
+        }
+
+        foreach (GameObject obs in obstacles)
+        {
+            if (!IsViewedBy(obs.GetComponent<Obstacle_RevealedTo>().GetObservedBy()))
+            {
+                obs.layer = 10;
+            }
+        }
+
+        foreach (GameObject fog in fogCells)
+        {
+            if (IsViewedBy(fog.GetComponent<FogHideOtherObject>().GetObservedBy()))
+            {
+                fog.layer = 10;
+            }
+            else
+            {
+                fog.layer = 0;
+            }
+        }
+    }
+
+    private void OnPreRender()
+    {
+        foreach (GameObject obs in GameObject.FindGameObjectsWithTag("Obstacle"))
+        {
+            obs.layer = 9;
+        }
+    }
+
+    private bool IsViewedBy(GameObject[] visTo)
+    {
+        foreach (GameObject v in visTo)
+        {
+            if (figs.ownedFigurine.Equals(v))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void OnEnable()
+    {
+        Camera.onPreCull += CullInvisible;
+    }
+
+    private void OnDisable()
+    {
+        Camera.onPreCull -= CullInvisible;
+    }
+}

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs.meta
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fef1b1f1dac4624b8225e8bd765721b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
@@ -4,11 +4,32 @@ using UnityEngine;
 
 public class PlayerOwnedFigurines : MonoBehaviour
 {
+    // This should probably be removed later, but it is good for debugging purposes.
     public GameObject ownedFigurine;
+    private List<GameObject> ownedFigurines = new List<GameObject>();
+
+    private void Start()
+    {
+        AddFigurine(ownedFigurine);
+    }
+
+    public void AddFigurine(GameObject fig)
+    {
+        if (!ownedFigurines.Contains(fig))
+        {
+            ownedFigurines.Add(fig);
+        }
+    }
+
+    public bool RemoveFigurine(GameObject fig)
+    {
+        return ownedFigurines.Remove(fig);
+    }
 
     public GameObject[] GetOwnedFigurines()
     {
-        GameObject[] retArr = { ownedFigurine };
-        return retArr;
+        // GameObject[] retList = new GameObject[ownedFigurines.Count];
+        // ownedFigurines.CopyTo(retList);
+        return ownedFigurines.ToArray();
     }
 }

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerOwnedFigurines : MonoBehaviour
+{
+    public GameObject ownedFigurine;
+}

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
@@ -5,12 +5,15 @@ using UnityEngine;
 public class PlayerOwnedFigurines : MonoBehaviour
 {
     // This should probably be removed later, but it is good for debugging purposes.
-    public GameObject ownedFigurine;
+    public GameObject[] inputFigurines;
     private List<GameObject> ownedFigurines = new List<GameObject>();
 
     private void Start()
     {
-        AddFigurine(ownedFigurine);
+        foreach (GameObject fig in inputFigurines)
+        {
+            AddFigurine(fig);
+        }
     }
 
     public void AddFigurine(GameObject fig)

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
@@ -5,4 +5,10 @@ using UnityEngine;
 public class PlayerOwnedFigurines : MonoBehaviour
 {
     public GameObject ownedFigurine;
+
+    public GameObject[] GetOwnedFigurines()
+    {
+        GameObject[] retArr = { ownedFigurine };
+        return retArr;
+    }
 }

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs.meta
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 420b744de58945f48910a62192b87734
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/ProjectSettings/TagManager.asset
+++ b/SNEL-VR/ProjectSettings/TagManager.asset
@@ -20,7 +20,7 @@ TagManager:
   - 
   - PostProcessing
   - ObstacleLayer
-  - 
+  - InvisibleLayer
   - 
   - 
   - 


### PR DESCRIPTION
# "Patch notes"
- Allows players to own figurines and only shows each player what their figurines can reveal. 
- Changes how objects are determined whether or not they should be visible:
  - The old method made all objects in a fog cell whenever any figurine had line of sight to them.
  - The new method adds the figurine observing the fog cell to a list of what figurines are observing the object in question.
- Changes how fog cells switch materials:
  - The old method switched the material in the fog cell when it was viewed for the first time.
  - The new method stores what figurines have viewed the fog cell and then changes the material right before rendering it to allow multiple people to have different appearances of the same fog cell.
- Changes how objects become invisible:
  - The old method relied on disabling/enabling the mesh grid to control visibility.
  - The new method relies on switching layers right before the camera decides whether something should be rendered or not.