### PR TITLE
Feature/improved culling calls

### DIFF
--- a/SNEL-VR/Assets/Materials/Fog.mat
+++ b/SNEL-VR/Assets/Materials/Fog.mat
@@ -9,13 +9,12 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Fog
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON _GLOSSYREFLECTIONS_OFF _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+  m_ShaderKeywords: _GLOSSYREFLECTIONS_OFF _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
-  stringTagMap:
-    RenderType: Transparent
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -60,19 +59,19 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 10
+    - _DstBlend: 0
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
     - _Metallic: 0
-    - _Mode: 3
+    - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 1
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _Color: {r: 0.26699895, g: 0.4528302, b: 0.44683564, a: 0.9254902}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/SNEL-VR/Assets/Materials/FogVisited.mat
+++ b/SNEL-VR/Assets/Materials/FogVisited.mat
@@ -9,13 +9,12 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: FogVisited
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON _GLOSSYREFLECTIONS_OFF _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+  m_ShaderKeywords: _GLOSSYREFLECTIONS_OFF _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
-  stringTagMap:
-    RenderType: Transparent
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -60,19 +59,19 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 10
+    - _DstBlend: 0
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
     - _Metallic: 0
-    - _Mode: 3
+    - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 1
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _Color: {r: 0.52224994, g: 0.6792453, b: 0.6739248, a: 0.5254902}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/SNEL-VR/Assets/Objects/EnvironmentalEffects/FogOfWar/FogElement.prefab
+++ b/SNEL-VR/Assets/Objects/EnvironmentalEffects/FogOfWar/FogElement.prefab
@@ -43,7 +43,6 @@ GameObject:
   - component: {fileID: 865640661906320691}
   - component: {fileID: 865640661906320690}
   - component: {fileID: 865640661906320689}
-  - component: {fileID: 865640661906320684}
   m_Layer: 0
   m_Name: FogCell
   m_TagString: Fog
@@ -123,15 +122,3 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &865640661906320684
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 865640661906320695}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ec0cdbb16a555944be36a3488836fab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 3508976374353388247}
   - component: {fileID: 7605154039241910277}
   - component: {fileID: 8356015031441935314}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: Figurine
   m_TagString: NPCFigurine
   m_Icon: {fileID: 0}

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 3508976374353388247}
   - component: {fileID: 7605154039241910277}
   - component: {fileID: 8356015031441935314}
+  - component: {fileID: 6113233158105435754}
   m_Layer: 15
   m_Name: Figurine
   m_TagString: NPCFigurine
@@ -103,6 +104,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1c9a2831845ee1c409eec91cd3f10562, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6113233158105435754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2691590353112806813}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ba7b3357ef64284599db9a5b00e3582, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &3054508066924389319

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Enemy.prefab
@@ -9,10 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1185474669484261747}
-  - component: {fileID: 2477168774654719724}
-  - component: {fileID: 3508976374353388247}
+  - component: {fileID: 7694890396915549077}
+  - component: {fileID: 1355929932599738251}
   - component: {fileID: 7605154039241910277}
-  - component: {fileID: 8356015031441935314}
   - component: {fileID: 6113233158105435754}
   m_Layer: 15
   m_Name: Figurine
@@ -29,13 +28,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2691590353112806813}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 0.39999998, y: 0.5, z: 0.39999998}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 592458350434367236}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &2477168774654719724
+--- !u!33 &7694890396915549077
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -43,7 +42,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2691590353112806813}
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &3508976374353388247
+--- !u!23 &1355929932599738251
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -94,18 +93,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &8356015031441935314
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2691590353112806813}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c9a2831845ee1c409eec91cd3f10562, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6113233158105435754
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -127,6 +114,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 592458350434367236}
+  - component: {fileID: 1916914350139548179}
   - component: {fileID: 2118803281066312270}
   - component: {fileID: 7146580516587749970}
   - component: {fileID: 198130520925876260}
@@ -146,13 +134,21 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3054508066924389319}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.4, y: 0.5, z: 0.4}
   m_Children:
   - {fileID: 1185474669484261747}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1916914350139548179
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3054508066924389319}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &2118803281066312270
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -201,8 +197,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.4, y: 1, z: 0.4}
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Size: {x: 1, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &198130520925876260
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
@@ -9,10 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8829548002214755706}
-  - component: {fileID: 8829548002214755654}
-  - component: {fileID: 8829548002214755655}
+  - component: {fileID: 6839150001458081323}
+  - component: {fileID: 913346847307270955}
   - component: {fileID: 8829548002214755704}
-  - component: {fileID: 6057943356348471409}
+  - component: {fileID: 7980673145683227510}
   m_Layer: 15
   m_Name: Figurine
   m_TagString: PlayerFigurine
@@ -28,13 +28,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8829548002214755707}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 0.4, y: 0.5, z: 0.4}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8829548002790330798}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8829548002214755654
+--- !u!33 &6839150001458081323
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -42,7 +42,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8829548002214755707}
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8829548002214755655
+--- !u!23 &913346847307270955
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -93,7 +93,7 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &6057943356348471409
+--- !u!114 &7980673145683227510
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -102,7 +102,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8829548002214755707}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c9a2831845ee1c409eec91cd3f10562, type: 3}
+  m_Script: {fileID: 11500000, guid: 1ba7b3357ef64284599db9a5b00e3582, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &8829548002790330799
@@ -114,12 +114,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8829548002790330798}
-  - component: {fileID: 8583217573666222473}
+  - component: {fileID: 823406892291023798}
+  - component: {fileID: 4042233920487492953}
   - component: {fileID: 6074542310561677180}
   - component: {fileID: 6225008706439102049}
-  - component: {fileID: 4042233920487492953}
+  - component: {fileID: 8583217573666222473}
   - component: {fileID: 7454281258740513498}
-  - component: {fileID: 8637658535423277644}
   m_Layer: 10
   m_Name: Figurine_Player
   m_TagString: Untagged
@@ -135,61 +135,22 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8829548002790330799}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.4, y: 0.5, z: 0.4}
   m_Children:
   - {fileID: 8829548002214755706}
   - {fileID: 8664666460849847683}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8583217573666222473
-MonoBehaviour:
+--- !u!33 &823406892291023798
+MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8829548002790330799}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7d1a7708e76601b4ea829921c33bc624, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_allowOffhandGrab: 1
-  m_snapPosition: 0
-  m_snapOrientation: 0
-  m_snapOffset: {fileID: 0}
-  m_grabPoints: []
-  m_materialColorField: 
---- !u!54 &6074542310561677180
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8829548002790330799}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 3
---- !u!65 &6225008706439102049
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8829548002790330799}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.4, y: 1, z: 0.4}
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &4042233920487492953
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -227,6 +188,53 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!54 &6074542310561677180
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8829548002790330799}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 3
+--- !u!65 &6225008706439102049
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8829548002790330799}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8583217573666222473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8829548002790330799}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d1a7708e76601b4ea829921c33bc624, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_allowOffhandGrab: 1
+  m_snapPosition: 0
+  m_snapOrientation: 0
+  m_snapOffset: {fileID: 0}
+  m_grabPoints: []
+  m_materialColorField: 
 --- !u!114 &7454281258740513498
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -240,18 +248,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitForFrames: 3
---- !u!114 &8637658535423277644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8829548002790330799}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1ba7b3357ef64284599db9a5b00e3582, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8976180846669872145
 GameObject:
   m_ObjectHideFlags: 0
@@ -279,7 +275,7 @@ Transform:
   m_GameObject: {fileID: 8976180846669872145}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2.5, y: 2, z: 2.5}
   m_Children: []
   m_Father: {fileID: 8829548002790330798}
   m_RootOrder: 1

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8829548002214755655}
   - component: {fileID: 8829548002214755704}
   - component: {fileID: 6057943356348471409}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: Figurine
   m_TagString: PlayerFigurine
   m_Icon: {fileID: 0}

--- a/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
+++ b/SNEL-VR/Assets/Objects/Figurines/Figurine_Player.prefab
@@ -119,6 +119,7 @@ GameObject:
   - component: {fileID: 6225008706439102049}
   - component: {fileID: 4042233920487492953}
   - component: {fileID: 7454281258740513498}
+  - component: {fileID: 8637658535423277644}
   m_Layer: 10
   m_Name: Figurine_Player
   m_TagString: Untagged
@@ -239,6 +240,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitForFrames: 3
+--- !u!114 &8637658535423277644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8829548002790330799}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ba7b3357ef64284599db9a5b00e3582, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8976180846669872145
 GameObject:
   m_ObjectHideFlags: 0

--- a/SNEL-VR/Assets/Objects/Obstacles/Obstacle_Wall.prefab
+++ b/SNEL-VR/Assets/Objects/Obstacles/Obstacle_Wall.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
@@ -100,6 +100,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e8315d6f2777c641af712c1479af57d, type: 3}
@@ -129,7 +144,7 @@ PrefabInstance:
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
@@ -176,6 +191,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e8315d6f2777c641af712c1479af57d, type: 3}
 --- !u!4 &7543436919341518750 stripped
@@ -204,7 +234,7 @@ PrefabInstance:
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
@@ -251,6 +281,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e8315d6f2777c641af712c1479af57d, type: 3}
 --- !u!4 &7543436919819389115 stripped
@@ -279,7 +324,7 @@ PrefabInstance:
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
         type: 3}
@@ -325,6 +370,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950841269433147973, guid: 2e8315d6f2777c641af712c1479af57d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e8315d6f2777c641af712c1479af57d, type: 3}

--- a/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
+++ b/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
@@ -53,10 +53,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2950841269136768742}
-  - component: {fileID: 2950841269136768746}
-  - component: {fileID: 2950841269136768741}
+  - component: {fileID: 1568462804293670333}
+  - component: {fileID: 3827501336093751171}
   - component: {fileID: 2950841269136768740}
-  - component: {fileID: 1578742081763624466}
   m_Layer: 15
   m_Name: WallSegment
   m_TagString: Obstacle
@@ -78,7 +77,7 @@ Transform:
   m_Father: {fileID: 2950841269433147973}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &2950841269136768746
+--- !u!33 &1568462804293670333
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -86,7 +85,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2950841269136768737}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &2950841269136768741
+--- !u!23 &3827501336093751171
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -136,18 +135,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0, y: 1, z: 0}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &1578742081763624466
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2950841269136768737}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 56bfa57c058a6a04cbc5858cd152f40f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2950841269433147972
 GameObject:
   m_ObjectHideFlags: 0
@@ -157,11 +144,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2950841269433147973}
-  - component: {fileID: 6280791993599369965}
   - component: {fileID: 1425572092527964793}
   - component: {fileID: 555536628909874264}
-  - component: {fileID: 3068390338289977004}
-  m_Layer: 10
+  m_Layer: 0
   m_Name: Obstacle_WallSegment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -184,43 +169,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &6280791993599369965
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2950841269433147972}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8e216c3218f3b9944a53c040b07780d5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!65 &1425572092527964793
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -250,21 +198,3 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 3
---- !u!114 &3068390338289977004
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2950841269433147972}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7d1a7708e76601b4ea829921c33bc624, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_allowOffhandGrab: 1
-  m_snapPosition: 0
-  m_snapOrientation: 0
-  m_snapOffset: {fileID: 0}
-  m_grabPoints: []
-  m_materialColorField: 

--- a/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
+++ b/SNEL-VR/Assets/Objects/Obstacles/Obstacle_WallSegment.prefab
@@ -1,5 +1,49 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1470325469106416332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8852844773278788685}
+  - component: {fileID: 5590015595180951525}
+  m_Layer: 9
+  m_Name: WallObstacle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8852844773278788685
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1470325469106416332}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2950841269433147973}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &5590015595180951525
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1470325469106416332}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.99, y: 1, z: 0.99}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2950841269136768737
 GameObject:
   m_ObjectHideFlags: 0
@@ -12,9 +56,8 @@ GameObject:
   - component: {fileID: 2950841269136768746}
   - component: {fileID: 2950841269136768741}
   - component: {fileID: 2950841269136768740}
-  - component: {fileID: 2950841269136768743}
   - component: {fileID: 1578742081763624466}
-  m_Layer: 9
+  m_Layer: 15
   m_Name: WallSegment
   m_TagString: Obstacle
   m_Icon: {fileID: 0}
@@ -29,8 +72,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2950841269136768737}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.75, z: 0}
-  m_LocalScale: {x: 0.25, y: 1.5, z: 0.25}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2950841269433147973}
   m_RootOrder: 0
@@ -88,27 +131,11 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2950841269136768737}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.99, y: 1, z: 0.99}
+  m_Size: {x: 0, y: 1, z: 0}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &2950841269136768743
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2950841269136768737}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 126
-  m_CollisionDetection: 0
 --- !u!114 &1578742081763624466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -130,7 +157,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2950841269433147973}
-  m_Layer: 0
+  - component: {fileID: 6280791993599369965}
+  - component: {fileID: 1425572092527964793}
+  - component: {fileID: 555536628909874264}
+  - component: {fileID: 3068390338289977004}
+  m_Layer: 10
   m_Name: Obstacle_WallSegment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -149,6 +180,91 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2950841269136768742}
+  - {fileID: 8852844773278788685}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &6280791993599369965
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2950841269433147972}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8e216c3218f3b9944a53c040b07780d5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &1425572092527964793
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2950841269433147972}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &555536628909874264
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2950841269433147972}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 3
+--- !u!114 &3068390338289977004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2950841269433147972}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d1a7708e76601b4ea829921c33bc624, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_allowOffhandGrab: 1
+  m_snapPosition: 0
+  m_snapOrientation: 0
+  m_snapOffset: {fileID: 0}
+  m_grabPoints: []
+  m_materialColorField: 

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -320,36 +320,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Figurine_Player2
       objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.050000004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.050000004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -404,6 +374,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.050000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.050000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5232382488076646358, guid: 0066209f147558e4aaa50845efe55dcf,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0066209f147558e4aaa50845efe55dcf, type: 3}
@@ -1585,6 +1585,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Figurine_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054508066924389319, guid: 66f8d895dabee83468dba0de87b8946b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
         type: 3}
@@ -3433,6 +3438,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: FogSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 7647315897191392820, guid: 967bf2c1d426be048a21af9760df9aab,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7647315897191392818, guid: 967bf2c1d426be048a21af9760df9aab,
         type: 3}

--- a/SNEL-VR/Assets/Scenes/SampleScene.unity
+++ b/SNEL-VR/Assets/Scenes/SampleScene.unity
@@ -259,7 +259,7 @@ PrefabInstance:
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8829548002790330798, guid: 0919273d5666bf944ba903096ea2cc5a,
         type: 3}
@@ -1599,7 +1599,7 @@ PrefabInstance:
     - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 592458350434367236, guid: 66f8d895dabee83468dba0de87b8946b,
         type: 3}
@@ -2736,6 +2736,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Obstacle_Wall
       objectReference: {fileID: 0}
+    - target: {fileID: 4637816363565740481, guid: 194a84b963922914b8e943b4d07649a7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4637816363565740482, guid: 194a84b963922914b8e943b4d07649a7,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3425,6 +3430,41 @@ PrefabInstance:
       propertyPath: show
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1136089980047273883, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: m_focusColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1136089980047273883, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: m_focusColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1138124198083297967, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: m_focusColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1138124198083297967, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: m_focusColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1032175183010609493, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: OutlineColorInRange.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1032175183010609493, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: OutlineColorInRange.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1032175183010609493, guid: d1b40ba5e9107a84fa5937bdb083d981,
+        type: 3}
+      propertyPath: OutlineColorHighlighted.a
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d1b40ba5e9107a84fa5937bdb083d981, type: 3}
 --- !u!1001 &7647315897910301335
@@ -3498,6 +3538,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7647315897191392819, guid: 967bf2c1d426be048a21af9760df9aab,
+        type: 3}
+      propertyPath: cellSizeVer
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 967bf2c1d426be048a21af9760df9aab, type: 3}

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_ObservedBy.cs
@@ -4,14 +4,11 @@ using UnityEngine;
 
 public class Figurine_ObservedBy : MonoBehaviour
 {
-    private List<GameObject> observedBy = new List<GameObject>();
+    private HashSet<GameObject> observedBy = new HashSet<GameObject>();
 
     public void AddObserver(GameObject observer)
     {
-        if (!observedBy.Contains(observer))
-        {
-            observedBy.Add(observer);
-        }
+        observedBy.Add(observer);
     }
 
     public void RemoveObserver(GameObject observer)
@@ -24,8 +21,8 @@ public class Figurine_ObservedBy : MonoBehaviour
         observedBy.Clear();
     }
 
-    public GameObject[] GetObservedBy()
+    public HashSet<GameObject> GetObservedBy()
     {
-        return observedBy.ToArray();
+        return observedBy;
     }
 }

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
@@ -206,13 +206,7 @@ public class Figurine_PlayerVision : MonoBehaviour
     // Tells a fog element it is no longer visible.
     private void TellOutOfLOS(GameObject other)
     {
-        if (other.CompareTag("Fog"))
-        {
-            other.GetComponent<FogHideOtherObject>().NotSeenBy(figurine);
-
-            tempKnownObjects.Remove(other);
-        }
-        else if (!other.CompareTag("Obstacle"))
+        if (!other.CompareTag("Obstacle"))
         {
             tempKnownObjects.Remove(other);
         }
@@ -223,8 +217,6 @@ public class Figurine_PlayerVision : MonoBehaviour
     {
         if (other.CompareTag("Fog"))
         {
-            other.GetComponent<FogHideOtherObject>().SeenBy(figurine);
-
             permKnownObjects.Add(other);
             tempKnownObjects.Add(other);
         }

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
@@ -17,11 +17,10 @@ public class Figurine_PlayerVision : MonoBehaviour
     private Transform parentTransform;
     private GameObject figurine;
 
-    private HashSet<Collider> fogOrFigExitingRange;
-    private HashSet<GameObject> fogCellsInRange;
-    private HashSet<GameObject> knownFogCells;
-    private HashSet<GameObject> figsInRange;
-    private HashSet<GameObject> knownObstacles;
+    private HashSet<Collider> tempKnownObjectExitingRange;
+
+    private HashSet<GameObject> permKnownObjects;
+    private HashSet<GameObject> tempKnownObjects;
 
     // Called whenever the fog should be updated from the figurine's perspective.
     public void ShouldUpdate()
@@ -49,17 +48,17 @@ public class Figurine_PlayerVision : MonoBehaviour
         // Used for LoS-updates in fog elements.
         figurine = parentTransform.gameObject;
 
-        fogOrFigExitingRange = new HashSet<Collider>();
-        fogCellsInRange = new HashSet<GameObject>();
-        knownFogCells = new HashSet<GameObject>();
-        figsInRange = new HashSet<GameObject>();
-        knownObstacles = new HashSet<GameObject>();
+        tempKnownObjectExitingRange = new HashSet<Collider>();
 
+        permKnownObjects = new HashSet<GameObject>();
+        tempKnownObjects = new HashSet<GameObject>();
+
+        // Adds the attached figurine to the set of permanently known objects.
         foreach (Transform child in parentTransform)
         {
             if (child.gameObject.CompareTag("PlayerFigurine"))
             {
-                figsInRange.Add(child.gameObject);
+                permKnownObjects.Add(child.gameObject);
                 break;
             }
         }
@@ -71,11 +70,11 @@ public class Figurine_PlayerVision : MonoBehaviour
         pos = parentTransform.position;
         if (hasUpdated)
         {
-            foreach (Collider c in fogOrFigExitingRange)
+            foreach (Collider c in tempKnownObjectExitingRange)
             {
                 OnTriggerStay(c);
             }
-            fogOrFigExitingRange.Clear();
+            tempKnownObjectExitingRange.Clear();
 
             shouldUpdate = false;
             hasUpdated = false;
@@ -131,7 +130,7 @@ public class Figurine_PlayerVision : MonoBehaviour
         }
 
         // No need to do any more calls if the obstacle is already known.
-        if (knownObstacles.Contains(other.gameObject))
+        if (permKnownObjects.Contains(other.gameObject))
         {
             return true;
         }
@@ -200,7 +199,7 @@ public class Figurine_PlayerVision : MonoBehaviour
     {
         if (ColliderHasTag(other, "Fog") || ColliderHasTag(other, "NPCFigurine") || ColliderHasTag(other, "PlayerFigurine"))
         {
-            fogOrFigExitingRange.Add(other);
+            tempKnownObjectExitingRange.Add(other);
         }
     }
 
@@ -211,11 +210,11 @@ public class Figurine_PlayerVision : MonoBehaviour
         {
             other.GetComponent<FogHideOtherObject>().NotSeenBy(figurine);
 
-            fogCellsInRange.Remove(other);
+            tempKnownObjects.Remove(other);
         }
         else if (!other.CompareTag("Obstacle"))
         {
-            figsInRange.Remove(other);
+            tempKnownObjects.Remove(other);
         }
     }
 
@@ -226,16 +225,16 @@ public class Figurine_PlayerVision : MonoBehaviour
         {
             other.GetComponent<FogHideOtherObject>().SeenBy(figurine);
 
-            fogCellsInRange.Add(other);
-            knownFogCells.Add(other);
+            permKnownObjects.Add(other);
+            tempKnownObjects.Add(other);
         }
         else if (other.CompareTag("Obstacle"))
         {
-            knownObstacles.Add(other);
+            permKnownObjects.Add(other);
         }
         else
         {
-            figsInRange.Add(other);
+            tempKnownObjects.Add(other);
         }
     }
 
@@ -264,23 +263,13 @@ public class Figurine_PlayerVision : MonoBehaviour
         return false;
     }
 
-    public HashSet<GameObject> GetFogCellsInRange()
+    public HashSet<GameObject> GetTempKnownObjects()
     {
-        return fogCellsInRange;
+        return tempKnownObjects;
     }
 
-    public HashSet<GameObject> GetKnownFogCells()
+    public HashSet<GameObject> GetPermKnownObjects()
     {
-        return knownFogCells;
-    }
-
-    public HashSet<GameObject> GetFigsInRange()
-    {
-        return figsInRange;
-    }
-
-    public HashSet<GameObject> GetKnownObstacles()
-    {
-        return knownObstacles;
+        return permKnownObjects;
     }
 }

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_PlayerVision.cs
@@ -75,14 +75,12 @@ public class Figurine_PlayerVision : MonoBehaviour
             }
             fogOrFigExitingRange.Clear();
 
-            Debug.Log("Amount of figs in range: " + figsInRange.Count);
-
             shouldUpdate = false;
             hasUpdated = false;
         }
     }
 
-    // Checks if a fog element is visible or not and sends the appropriate call to its script.
+    // Checks if a collider should have its visibility sttus updated.
     private void OnTriggerStay(Collider other)
     {
         // Does not update anything if the figurine has not moved.
@@ -94,31 +92,40 @@ public class Figurine_PlayerVision : MonoBehaviour
 
         if (ColliderHasTag(other, "Fog") || ColliderHasTag(other, "NPCFigurine") || ColliderHasTag(other, "PlayerFigurine"))
         {
-            Vector3 otherPos = other.gameObject.GetComponent<Transform>().position;
-            Vector3 direction = otherPos - (sphereCenter + pos);
-            float raycastRange = direction.magnitude;
+            UpdateColliderStatus(other);
+        }
+    }
 
-            // Checks if the other object is out of range.
-            if (raycastRange > visionRange)
+    // Checks if the collider belongs to an object that should be visible to this figurine's owner.
+    // Returns true if the object is within the visibility range, and false if it is outside it.
+    public bool UpdateColliderStatus(Collider other)
+    {
+        Vector3 otherPos = other.gameObject.GetComponent<Transform>().position;
+        Vector3 direction = otherPos - (sphereCenter + pos);
+        float raycastRange = direction.magnitude;
+
+        // Checks if the other object is out of range.
+        if (raycastRange > visionRange)
+        {
+            TellOutOfLOS(other.gameObject);
+            return false;
+        }
+        else
+        {
+            // Checks if there is an obstacle between the figurine and fog element.
+            if (Physics.Raycast(sphereCenter + pos, direction, raycastRange, obstacleLayerMask))
             {
+                // Is an obstacle.
+                Debug.DrawLine(sphereCenter + pos, otherPos, Color.red);
                 TellOutOfLOS(other.gameObject);
             }
             else
             {
-                // Checks if there is an obstacle between the figurine and fog element.
-                if (Physics.Raycast(sphereCenter + pos, direction, raycastRange, obstacleLayerMask))
-                {
-                    // Is an obstacle.
-                    Debug.DrawLine(sphereCenter + pos, otherPos, Color.red);
-                    TellOutOfLOS(other.gameObject);
-                }
-                else
-                {
-                    // Is no obstacle.
-                    Debug.DrawLine(sphereCenter + pos, otherPos, Color.green);
-                    TellInLOS(other.gameObject);
-                }
+                // Is no obstacle.
+                Debug.DrawLine(sphereCenter + pos, otherPos, Color.green);
+                TellInLOS(other.gameObject);
             }
+            return true;
         }
     }
 

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_RemoveFromPlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_RemoveFromPlayerVision.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using OVRTouchSample;
+using UnityEngine;
+
+public class Figurine_RemoveFromPlayerVision : MonoBehaviour
+{
+    private OculusSampleFramework.DistanceGrabbable distanceGrabbable;
+    private HashSet<Figurine_PlayerVision> observers;
+    private Transform parentTransform;
+    private GameObject figurine;
+    private Collider thisCollider;
+    private Vector3 oldPos;
+
+    private bool hasMoved = false;
+    private float sensitivity = 0.00001f;
+
+    private void OnEnable()
+    {
+        observers = new HashSet<Figurine_PlayerVision>();
+
+        figurine = this.gameObject;
+        parentTransform = figurine.GetComponent<Transform>().parent;
+        thisCollider = figurine.GetComponent<Collider>();
+        distanceGrabbable = parentTransform.gameObject.GetComponent<OculusSampleFramework.DistanceGrabbable>();
+
+        oldPos = parentTransform.position;
+    }
+
+    private void FixedUpdate()
+    {
+        Vector3 newPos = parentTransform.position;
+        bool justMoved = (oldPos - newPos).sqrMagnitude > sensitivity;
+        bool hasStopped = hasMoved && !justMoved;
+
+        // Checks if th figurine has stopped moving and is not being held.
+        if (hasStopped && !distanceGrabbable.isGrabbed)
+        {
+            HashSet<Figurine_PlayerVision> toBeRemoved = new HashSet<Figurine_PlayerVision>();
+
+            // Updates the visibility status of this figurine for each player figurine observing it.
+            // Stops checking scripts of figurines that are too far away.
+            foreach (Figurine_PlayerVision obs in observers)
+            {
+                if (!obs.UpdateColliderStatus(thisCollider))
+                {
+                    toBeRemoved.Add(obs);
+                }
+            }
+
+            observers.ExceptWith(toBeRemoved);
+        }
+
+        hasMoved = justMoved;
+        oldPos = newPos;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.CompareTag("PlayerFigurineVision"))
+        {
+            observers.Add(other.GetComponent<Figurine_PlayerVision>());
+        }
+    }
+}

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_RemoveFromPlayerVision.cs.meta
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_RemoveFromPlayerVision.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ba7b3357ef64284599db9a5b00e3582
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_UpdatePlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_UpdatePlayerVision.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using OVRTouchSample;
 using UnityEngine;

--- a/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_UpdatePlayerVision.cs
+++ b/SNEL-VR/Assets/Scripts/FigurineScripts/Figurine_UpdatePlayerVision.cs
@@ -63,6 +63,7 @@ public class Figurine_UpdatePlayerVision : MonoBehaviour
                 awaitStandstill = true;
                 oldPos = figTransform.position;
                 waitedFrames = 0;
+                wasGrabbed = false;
             }
             else
             {

--- a/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
+++ b/SNEL-VR/Assets/Scripts/FogScripts/FogHideOtherObject.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 public class FogHideOtherObject : MonoBehaviour
 {
-    private List<Collider> figurineColliders = new List<Collider>();
-    private List<Collider> obstacleColliders = new List<Collider>();
+    private HashSet<Collider> figurineColliders = new HashSet<Collider>();
+    private HashSet<Collider> obstacleColliders = new HashSet<Collider>();
 
-    private List<GameObject> observedBy = new List<GameObject>();
-    private List<GameObject> hasBeenObservedBy = new List<GameObject>();
+    private HashSet<GameObject> observedBy = new HashSet<GameObject>();
+    private HashSet<GameObject> hasBeenObservedBy = new HashSet<GameObject>();
 
     private void OnTriggerEnter(Collider other)
     {
@@ -19,29 +19,23 @@ public class FogHideOtherObject : MonoBehaviour
             other.gameObject.GetComponent<Figurine_ObservedBy>().ClearObservers();
 
             // Make the figurine visible to all figurines currently observing this fog element.
-            for (int i = 0; i < observedBy.Count; i++)
+            foreach (GameObject fig in observedBy)
             {
-                MakeVisible(other, observedBy[i]);
+                MakeVisible(other, fig);
             }
-
-            if (!figurineColliders.Contains(other))
-            {
-                figurineColliders.Add(other);
-            }
+            
+            figurineColliders.Add(other);
         }
         // What to do when colliding with an obstacle.
         else if (ColliderHasTag(other, "Obstacle"))
         {
             // Make the obstacle visible to all figurines currently observing this fog element.
-            for (int i = 0; i < observedBy.Count; i++)
+            foreach (GameObject fig in observedBy)
             {
-                MakeVisible(other, observedBy[i]);
+                MakeVisible(other, fig);
             }
 
-            if (!obstacleColliders.Contains(other))
-            {
-                obstacleColliders.Add(other);
-            }
+            obstacleColliders.Add(other);
         }
     }
 
@@ -66,14 +60,8 @@ public class FogHideOtherObject : MonoBehaviour
     // Called by a player's vision script when it has line of sight to the cell.
     public void SeenBy(GameObject figurine)
     {
-        if (!observedBy.Contains(figurine))
-        {
-            observedBy.Add(figurine);
-            if (!hasBeenObservedBy.Contains(figurine))
-            {
-                hasBeenObservedBy.Add(figurine);
-            }
-        }
+        observedBy.Add(figurine);
+        hasBeenObservedBy.Add(figurine);
         RevealContents(figurine);
     }
 
@@ -85,28 +73,28 @@ public class FogHideOtherObject : MonoBehaviour
     }
 
     // Reveal any and all objects hidden by this fog cell.
-    private void RevealContents(GameObject figurine)
+    private void RevealContents(GameObject playerFig)
     {
         // Make all NPC figurines visible
-        for (int i = 0; i < figurineColliders.Count; i++)
+        foreach (Collider fig in figurineColliders)
         {
-            MakeVisible(figurineColliders[i], figurine);
+            MakeVisible(fig, playerFig);
         }
 
         // Make all obstacles visible
-        for (int i = 0; i < obstacleColliders.Count; i++)
+        foreach (Collider obstacle in obstacleColliders)
         {
-            MakeVisible(obstacleColliders[i], figurine);
+            MakeVisible(obstacle, playerFig);
         }
     }
 
     // Hides all objects tagged with the NPCFigurines-tag that can be hidden by this fog cell.
-    private void HideContents(GameObject figurine)
+    private void HideContents(GameObject playerFig)
     {
         // Make all NPC figurines visible
-        for (int i = 0; i < figurineColliders.Count; i++)
+        foreach (Collider fig in figurineColliders)
         {
-            MakeInvisible(figurineColliders[i], figurine);
+            MakeInvisible(fig, playerFig);
         }
     }
 
@@ -144,13 +132,13 @@ public class FogHideOtherObject : MonoBehaviour
         }
     }
 
-    public GameObject[] GetObservedBy()
+    public HashSet<GameObject> GetObservedBy()
     {
-        return observedBy.ToArray();
+        return observedBy;
     }
 
-    public GameObject[] getHasBeenObservedBy()
+    public HashSet<GameObject> getHasBeenObservedBy()
     {
-        return hasBeenObservedBy.ToArray();
+        return hasBeenObservedBy;
     }
 }

--- a/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
+++ b/SNEL-VR/Assets/Scripts/ObstacleScripts/Obstacle_RevealedTo.cs
@@ -4,18 +4,15 @@ using UnityEngine;
 
 public class Obstacle_RevealedTo : MonoBehaviour
 {
-    private List<GameObject> observedBy = new List<GameObject>();
+    private HashSet<GameObject> observedBy = new HashSet<GameObject>();
 
     public void AddObserver(GameObject observer)
     {
-        if (!observedBy.Contains(observer))
-        {
-            observedBy.Add(observer);
-        }
+        observedBy.Add(observer);
     }
 
-    public GameObject[] GetObservedBy()
+    public HashSet<GameObject> GetObservedBy()
     {
-        return observedBy.ToArray();
+        return observedBy;
     }
 }

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
@@ -95,7 +95,7 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
     }
 
     // Checks if any object in the input array is owned by the player.
-    private bool OwnedIsIn(GameObject[] visTo)
+    private bool OwnedIsIn(HashSet<GameObject> visTo)
     {
         foreach (GameObject v in visTo)
         {
@@ -110,14 +110,7 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
     // Checks if the input object is owned by the player.
     private bool IsOwned(GameObject obj)
     {
-        foreach (GameObject own in figs.GetOwnedFigurines())
-        {
-            if (own.Equals(obj))
-            {
-                return true;
-            }
-        }
-        return false;
+        return figs.GetOwnedFigurines().Contains(obj);
     }
 
     // Adds CullInvisible to OnPreCull and get the ownedFigurines-script when enabled.

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerDisplayObjectDecider.cs
@@ -46,17 +46,6 @@ public class PlayerDisplayObjectDecider : MonoBehaviour
 
         // Put all fog elements visible by any owned figurines in the default layer and the rest
         // in the invisible layer.
-        /*foreach (GameObject fog in GameObject.FindGameObjectsWithTag("Fog"))
-        {
-            if (OwnedIsIn(fog.GetComponent<FogHideOtherObject>().GetObservedBy()))
-            {
-                fog.layer = invisibleLayer;
-            }
-            else
-            {
-                fog.layer = defaultLayer;
-            }
-        }*/
         foreach (GameObject playerFig in figs.GetOwnedFigurines())
         {
             invisibleFogCells.UnionWith(playerFig.GetComponentInChildren<Figurine_PlayerVision>().GetFogCellsInRange());

--- a/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
+++ b/SNEL-VR/Assets/Scripts/PlayerScripts/PlayerOwnedFigurines.cs
@@ -6,7 +6,7 @@ public class PlayerOwnedFigurines : MonoBehaviour
 {
     // This should probably be removed later, but it is good for debugging purposes.
     public GameObject[] inputFigurines;
-    private List<GameObject> ownedFigurines = new List<GameObject>();
+    private HashSet<GameObject> ownedFigurines = new HashSet<GameObject>();
 
     private void Start()
     {
@@ -18,10 +18,7 @@ public class PlayerOwnedFigurines : MonoBehaviour
 
     public void AddFigurine(GameObject fig)
     {
-        if (!ownedFigurines.Contains(fig))
-        {
-            ownedFigurines.Add(fig);
-        }
+        ownedFigurines.Add(fig);
     }
 
     public bool RemoveFigurine(GameObject fig)
@@ -29,10 +26,8 @@ public class PlayerOwnedFigurines : MonoBehaviour
         return ownedFigurines.Remove(fig);
     }
 
-    public GameObject[] GetOwnedFigurines()
+    public HashSet<GameObject> GetOwnedFigurines()
     {
-        // GameObject[] retList = new GameObject[ownedFigurines.Count];
-        // ownedFigurines.CopyTo(retList);
-        return ownedFigurines.ToArray();
+        return ownedFigurines;
     }
 }

--- a/SNEL-VR/ProjectSettings/EditorBuildSettings.asset
+++ b/SNEL-VR/ProjectSettings/EditorBuildSettings.asset
@@ -5,7 +5,10 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   - enabled: 1
     path: Assets/Scenes/SampleScene.unity
-    guid: 99c9720ab356a0642a771bea13969a05
+    guid: 60380acee19392a4981613c213baaa60
   m_configObjects: {}

--- a/SNEL-VR/ProjectSettings/GraphicsSettings.asset
+++ b/SNEL-VR/ProjectSettings/GraphicsSettings.asset
@@ -36,6 +36,8 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/SNEL-VR/ProjectSettings/ProjectVersion.txt
+++ b/SNEL-VR/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.11f1
+m_EditorVersion: 2018.3.12f1

--- a/SNEL-VR/ProjectSettings/UnityConnectSettings.asset
+++ b/SNEL-VR/ProjectSettings/UnityConnectSettings.asset
@@ -4,7 +4,7 @@
 UnityConnectSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 1
-  m_Enabled: 0
+  m_Enabled: 1
   m_TestMode: 0
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events


### PR DESCRIPTION
Streamlines the code determining what objects should be visible to the player and what materials the fog cells should have.
This includes:
- Moving to using HashSets insted of Lists
- Moving from having objects store what player figurine can and cannot "see" them to having the player figurines store what objects are in range and/or are permanently known.